### PR TITLE
Remove nokogiri depencency and use ruby alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.5.1-alpine
 
 # Fetch/install gems
 RUN mkdir -p /opt/gems

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'bundler', '~> 1.16'
 gem 'haml'
-gem 'nokogiri'
 
 group :development, :test do
   gem 'rake', '~> 10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,6 @@ GEM
       temple (>= 0.8.0)
       tilt
     json (2.1.0)
-    mini_portile2 (2.3.0)
-    nokogiri (1.8.2)
-      mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
@@ -53,7 +50,6 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.16)
   haml
-  nokogiri
   rake (~> 10.0)
   rspec (~> 3.0)
   rubocop

--- a/spec/test_summary_buildkite_plugin/input_spec.rb
+++ b/spec/test_summary_buildkite_plugin/input_spec.rb
@@ -66,10 +66,6 @@ RSpec.describe TestSummaryBuildkitePlugin::Input do
       expect(input.failures.first.details).to start_with('Failure/Error: ')
     end
 
-    it 'details escape html' do
-      expect(input.failures.first.details).to include('&lt;')
-    end
-
     it 'failures have file' do
       expect(input.failures.first.file).to eq('./spec/lib/url_whitelist_spec.rb')
     end


### PR DESCRIPTION
As per comments here: https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin/issues/5

version | image size
--- | ---
before | 926MB
alpine + build-base + nokogiri | 262MB
alpine + rexml | 88MB

We really don't need it, so lets just not.