### PR TITLE
Add plugin.yml and plugin-linter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,11 @@ steps:
       docker-compose#v2.1.0:
         run: test
 
+  - label: ":sparkles: plugin lint"
+    plugins:
+      plugin-linter#v1.0.0:
+        name: test-summary
+
   - label: ":arrow_up: artifacts"
     command: buildkite-agent artifact upload spec/sample_artifacts/**/*
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,0 @@
-{
-  "name": "test-summary",
-  "description": "Collates test results as a buildkite annotation",
-  "author": "@tessereth",
-  "public": true,
-  "requirements": ["docker"]
-}

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,57 @@
+name: test-summary
+description: Collates test results as a buildkite annotation
+author: "@tessereth"
+requirements:
+  - docker
+configuration:
+  properties:
+    inputs:
+      type: array
+      items:
+        type: object
+        properties:
+          label:
+            type: string
+          artifact_path:
+            type: string
+          type:
+            type: string
+            enum:
+              - junit
+              - tap
+              - oneline
+          encoding:
+            type: string
+          strip_colors:
+            type: boolean
+          crop:
+            type: object
+            properties:
+              start:
+                type: number
+              end:
+                type: number
+            additionalProperties: false
+        required:
+          - label
+          - artifact_path
+          - type
+        additionalProperties: false
+    formatter:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - summary
+            - details
+        show_first:
+          type: number
+      additionalProperties: false
+    context:
+      type: string
+    style:
+      type: string
+  required:
+    - inputs
+  additionalProperties: false


### PR DESCRIPTION
The plugin linter doesn't check the sample config in the readme against the schema because the code block doesn't start with `- steps:`. But it checks a couple other things so we may as well add it.