### PR TITLE
Junit: Support `error` elements and include the message

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,6 +34,9 @@ steps:
             type: junit
             encoding: UTF-8
             strip_colors: true
+          - label: ":speak_no_evil: xunit"
+            artifact_path: spec/sample_artifacts/xunit.xml
+            type: junit
           - label: ":camel: tap"
             artifact_path: spec/sample_artifacts/example.tap
             type: tap
@@ -63,6 +66,9 @@ steps:
             type: junit
             encoding: UTF-8
             strip_colors: true
+          - label: ":speak_no_evil: xunit"
+            artifact_path: spec/sample_artifacts/xunit.xml
+            type: junit
           - label: ":camel: tap"
             artifact_path: spec/sample_artifacts/example.tap
             type: tap

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,7 @@ steps:
             type: junit
             encoding: UTF-8
             strip_colors: true
-          - label: ":speak_no_evil: xunit"
+          - label: ":female-technologist: xunit"
             artifact_path: spec/sample_artifacts/xunit.xml
             type: junit
           - label: ":camel: tap"
@@ -66,7 +66,7 @@ steps:
             type: junit
             encoding: UTF-8
             strip_colors: true
-          - label: ":speak_no_evil: xunit"
+          - label: ":female-technologist: xunit"
             artifact_path: spec/sample_artifacts/xunit.xml
             type: junit
           - label: ":camel: tap"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Max: 120
 
+Metrics/MethodLength:
+  Max: 15
+
 Metrics/PerceivedComplexity:
   Max: 10
 

--- a/lib/test_summary_buildkite_plugin/failure.rb
+++ b/lib/test_summary_buildkite_plugin/failure.rb
@@ -43,7 +43,7 @@ module TestSummaryBuildkitePlugin
       private
 
       def location
-        "#{file}: " if file
+        "#{file}: " unless file.nil? || file.empty?
       end
     end
   end

--- a/lib/test_summary_buildkite_plugin/failure.rb
+++ b/lib/test_summary_buildkite_plugin/failure.rb
@@ -6,14 +6,6 @@ module TestSummaryBuildkitePlugin
     class Base
       attr_accessor :job_id
 
-      def summary
-        raise 'abstract method'
-      end
-
-      def details
-        raise 'abstract method'
-      end
-
       def strip_colors
         instance_variables.each do |var|
           value = instance_variable_get(var)
@@ -30,16 +22,17 @@ module TestSummaryBuildkitePlugin
       end
 
       def details; end
+
+      def message; end
     end
 
     class Structured < Base
-      attr_accessor :file, :line, :column, :name, :details
+      attr_accessor :file, :name, :message, :details
 
-      def initialize(name:, file: nil, line: nil, column: nil, details: nil)
+      def initialize(name:, file: nil, message: nil, details: nil)
         @file = file
-        @line = line
-        @column = column
         @name = name
+        @message = message
         @details = details
       end
 
@@ -50,8 +43,7 @@ module TestSummaryBuildkitePlugin
       private
 
       def location
-        reference = [file, line, column].compact.join(':')
-        "#{reference}: " unless reference.empty?
+        "#{file}: " if file
       end
     end
   end

--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -90,14 +90,19 @@ module TestSummaryBuildkitePlugin
       def file_contents_to_failures(str)
         xml = REXML::Document.new(str)
         xml.elements.enum_for(:each, '*/testcase').each_with_object([]) do |testcase, failures|
-          testcase.elements.each('failure') do |failure|
+          testcase.elements.each('failure | error') do |failure|
             failures << Failure::Structured.new(
               file: testcase.attributes['file'].to_s,
               name: testcase.attributes['name'].to_s,
-              details: failure.text
+              details: details(failure)
             )
           end
         end
+      end
+
+      def details(failure)
+        # gets all text elements that are direct children (includes CDATA), and use the unescaped values
+        failure.texts.map(&:value).join('').strip
       end
     end
 

--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -94,6 +94,7 @@ module TestSummaryBuildkitePlugin
             failures << Failure::Structured.new(
               file: testcase.attributes['file'].to_s,
               name: testcase.attributes['name'].to_s,
+              message: failure.attributes['message'].to_s,
               details: details(failure)
             )
           end

--- a/spec/sample_artifacts/xunit.xml
+++ b/spec/sample_artifacts/xunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="xunit" tests="2" skipped="1" failures="0" errors="1" time="9.658348" timestamp="2018-04-24T14:55:21+10:00" hostname="foo.local">
+  <testcase classname="Chrome 66.0" name="Unit | Component | autocomplete: shows default results when defaultCategory is set" time="0.070">
+    <error message="has results after focusing">
+      <![CDATA[
+at Object.<anonymous> (http://localhost:9001/assets/tests.js:2188:20) at runTest (http://localhost:9001/assets/test-support.js:15012:30) at Test.run (http://localhost:9001/assets/test-support.js:14998:6) at http://localhost:9001/assets/test-support.js:15210:12 at advanceTaskQueue (http://localhost:9001/assets/test-support.js:14611:6) at Object.advance (http://localhost:9001/assets/test-support.js:14592:4)
+]]>
+    </error>
+    <skipped message="not implemented">
+      <![CDATA[implementations are overrated]]>
+    </skipped>
+  </testcase>
+</testsuite>

--- a/spec/test_summary_buildkite_plugin/failure_spec.rb
+++ b/spec/test_summary_buildkite_plugin/failure_spec.rb
@@ -21,14 +21,17 @@ RSpec.describe TestSummaryBuildkitePlugin::Failure do
       end
 
       context 'with file' do
-        let(:line) { nil }
-        let(:column) { nil }
-
         it { expect(summary).to start_with("#{file}: ") }
       end
 
-      context 'with no location information' do
+      context 'with no file' do
         let(:file) { nil }
+
+        it { expect(summary).to eq(name) }
+      end
+
+      context 'with empty file' do
+        let(:file) { '' }
 
         it { expect(summary).to eq(name) }
       end

--- a/spec/test_summary_buildkite_plugin/failure_spec.rb
+++ b/spec/test_summary_buildkite_plugin/failure_spec.rb
@@ -5,11 +5,9 @@ require 'spec_helper'
 RSpec.describe TestSummaryBuildkitePlugin::Failure do
   describe TestSummaryBuildkitePlugin::Failure::Structured do
     let(:file) { 'foo.rb' }
-    let(:line) { 123 }
-    let(:column) { 79 }
     let(:name) { 'unicorns are\'t real' }
     let(:details) { 'This is a failure of great proportions' }
-    let(:params) { { file: file, line: line, column: column, name: name, details: details } }
+    let(:params) { { file: file, name: name, details: details } }
 
     describe 'summary' do
       subject(:summary) { described_class.new(params).summary }
@@ -22,17 +20,7 @@ RSpec.describe TestSummaryBuildkitePlugin::Failure do
         expect(summary).not_to include(details)
       end
 
-      context 'with file, line and column' do
-        it { expect(summary).to start_with("#{file}:#{line}:#{column}: ") }
-      end
-
-      context 'with only file and line' do
-        let(:column) { nil }
-
-        it { expect(summary).to start_with("#{file}:#{line}: ") }
-      end
-
-      context 'with only file' do
+      context 'with file' do
         let(:line) { nil }
         let(:column) { nil }
 
@@ -41,8 +29,6 @@ RSpec.describe TestSummaryBuildkitePlugin::Failure do
 
       context 'with no location information' do
         let(:file) { nil }
-        let(:line) { nil }
-        let(:column) { nil }
 
         it { expect(summary).to eq(name) }
       end

--- a/spec/test_summary_buildkite_plugin/input_spec.rb
+++ b/spec/test_summary_buildkite_plugin/input_spec.rb
@@ -95,6 +95,18 @@ RSpec.describe TestSummaryBuildkitePlugin::Input do
         expect(input.failures.first.details).not_to include('\e[0m')
       end
     end
+
+    context 'with error and skip elements' do
+      let(:artifact_path) { 'xunit.xml' }
+
+      it 'includes the error' do
+        expect(input.failures.first.name).to include('shows default results when defaultCategory is set')
+      end
+
+      it 'ignored skipped test' do
+        expect(input.failures.count).to eq(1)
+      end
+    end
   end
 
   describe 'with glob path' do

--- a/spec/test_summary_buildkite_plugin/input_spec.rb
+++ b/spec/test_summary_buildkite_plugin/input_spec.rb
@@ -74,14 +74,6 @@ RSpec.describe TestSummaryBuildkitePlugin::Input do
       expect(input.failures.first.name).to eq('UrlWhitelist with domain wildcard should be allowed url')
     end
 
-    it 'failures have no line' do
-      expect(input.failures.first.line).to be_nil
-    end
-
-    it 'failures have no column' do
-      expect(input.failures.first.column).to be_nil
-    end
-
     context 'without strip_colors' do
       it 'keeps color sequences' do
         expect(input.failures.first.details).to include('\e[0m')
@@ -144,14 +136,6 @@ severity: fail')
 
     it 'failures have no file' do
       expect(input.failures.first.file).to be_nil
-    end
-
-    it 'failures have no line' do
-      expect(input.failures.first.line).to be_nil
-    end
-
-    it 'failures have no column' do
-      expect(input.failures.first.column).to be_nil
     end
   end
 

--- a/templates/details/failures.html.haml
+++ b/templates/details/failures.html.haml
@@ -6,19 +6,24 @@
           %summary
             %code
               = failure.summary
-          - if failure.message
-            %p
-              = failure.message
-          - if failure.details
-            %pre
-              %code
-                = failure.details
-          - if failure.job_id
-            %p
-              in
-              %a{href: "#job-component-#{failure.job_id}"}
-                job
-                = failure.job_id
+          %dl
+            - if failure.message
+              %dt Message
+              %dd
+                %pre
+                  %code
+                    = failure.message
+            - if failure.details
+              %dt Details
+              %dd
+                %pre
+                  %code
+                    = failure.details
+            - if failure.job_id
+              %dt Job
+              %dd
+                %a{href: "#job-component-#{failure.job_id}"}
+                  = failure.job_id
       - else
         %code
           = failure.summary

--- a/templates/details/failures.html.haml
+++ b/templates/details/failures.html.haml
@@ -1,11 +1,14 @@
 %ul
   - failures.each do |failure|
     %li
-      - if failure.details || failure.job_id
+      - if failure.message || failure.details || failure.job_id
         %details
           %summary
             %code
               = failure.summary
+          - if failure.message
+            %p
+              = failure.message
           - if failure.details
             %pre
               %code


### PR DESCRIPTION
<img width="1099" alt="screen shot 2018-05-03 at 6 24 36 pm" src="https://user-images.githubusercontent.com/4583474/39566550-4ab76150-4eff-11e8-876f-d288a3b46a57.png">

closes #5 