### PR TITLE
Fallback to simpler formats if markdown is too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Other formatter options are:
   If set to zero, all failures will be hidden by default. If set to a negative number, all failures
   will be shown. Defaults to 20.
 
+**Note**: If the generated annotation exceeds the maximum allowed size, it will fallback from the `details` formatter
+to the `summary` formatter and then to only displaying the failure count for each input source.
+
 ### Other options
 
 * `context:` The Buildkite annotation context. Defaults to `test-summary`.

--- a/lib/test_summary_buildkite_plugin/formatter.rb
+++ b/lib/test_summary_buildkite_plugin/formatter.rb
@@ -4,62 +4,87 @@ require 'haml'
 
 module TestSummaryBuildkitePlugin
   class Formatter
-    attr_reader :options
-
-    def initialize(options = {})
-      @options = options || {}
-      raise "Unknown type: #{type}" unless %w[summary details].include?(type)
+    def self.create(**options)
+      options[:type] ||= 'details'
+      type = options[:type].to_sym
+      raise "Unknown type: #{type}" unless TYPES.key?(type)
+      TYPES[type].new(options)
     end
 
-    def markdown(input)
-      return nil if input.failures.count.zero?
-      [heading(input), input_markdown(input), footer(input)].compact.join("\n\n")
-    end
+    class Base
+      attr_reader :options
 
-    def input_markdown(input)
-      if show_first.negative? || show_first >= input.failures.count
-        failures_markdown(input.failures)
-      elsif show_first.zero?
-        details('Show failures', failures_markdown(input.failures))
-      else
-        failures_markdown(input.failures[0...show_first]) +
-          details('Show additional failures', failures_markdown(input.failures[show_first..-1]))
+      def initialize(options = {})
+        @options = options || {}
+      end
+
+      def markdown(input)
+        return nil if input.failures.count.zero?
+        [heading(input), input_markdown(input), footer(input)].compact.join("\n\n")
+      end
+
+      def input_markdown(input)
+        if show_first.negative? || show_first >= input.failures.count
+          failures_markdown(input.failures)
+        elsif show_first.zero?
+          details('Show failures', failures_markdown(input.failures))
+        else
+          failures_markdown(input.failures[0...show_first]) +
+            details('Show additional failures', failures_markdown(input.failures[show_first..-1]))
+        end
+      end
+
+      def failures_markdown(failures)
+        render_template('failures', failures: failures)
+      end
+
+      def heading(input)
+        count = input.failures.count
+        "##### #{input.label}: #{count} failure#{'s' unless count == 1}"
+      end
+
+      def footer(input)
+        job_ids = input.failures.map(&:job_id).uniq.reject(&:nil?)
+        render_template('footer', job_ids: job_ids)
+      end
+
+      def show_first
+        options[:show_first] || 20
+      end
+
+      def details(summary, contents)
+        # The empty paragraph puts padding between the details and the following element
+        "<details><summary>#{summary}</summary>\n#{contents}\n</details><p></p>"
+      end
+
+      def type
+        options[:type] || 'details'
+      end
+
+      def render_template(name, params)
+        filename = %W[templates/#{type}/#{name}.html.haml templates/#{name}.html.haml].find { |f| File.exist?(f) }
+        if filename
+          engine = Haml::Engine.new(File.read(filename), escape_html: true)
+          engine.render(Object.new, params)
+        end
       end
     end
 
-    def failures_markdown(failures)
-      render_template('failures', failures: failures)
-    end
+    class Summary < Base; end
 
-    def heading(input)
-      count = input.failures.count
-      "##### #{input.label}: #{count} failure#{'s' unless count == 1}"
-    end
+    class Details < Base; end
 
-    def footer(input)
-      job_ids = input.failures.map(&:job_id).uniq.reject(&:nil?)
-      render_template('footer', job_ids: job_ids)
-    end
-
-    def show_first
-      options[:show_first] || 20
-    end
-
-    def details(summary, contents)
-      # The empty paragraph puts padding between the details and the following element
-      "<details><summary>#{summary}</summary>\n#{contents}\n</details><p></p>"
-    end
-
-    def type
-      options[:type] || 'details'
-    end
-
-    def render_template(name, params)
-      filename = %W[templates/#{type}/#{name}.html.haml templates/#{name}.html.haml].find { |f| File.exist?(f) }
-      if filename
-        engine = Haml::Engine.new(File.read(filename), escape_html: true)
-        engine.render(Object.new, params)
+    class CountOnly < Base
+      def markdown(input)
+        return nil if input.failures.count.zero?
+        heading(input)
       end
     end
+
+    TYPES = {
+      summary: Formatter::Summary,
+      details: Formatter::Details,
+      count_only: Formatter::CountOnly
+    }.freeze
   end
 end

--- a/spec/test_summary_buildkite_plugin/formatter_spec.rb
+++ b/spec/test_summary_buildkite_plugin/formatter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TestSummaryBuildkitePlugin::Formatter do
   let(:input) { double(TestSummaryBuildkitePlugin::Input::Base, label: 'animals') }
   let(:failures) { [] }
 
-  subject(:markdown) { described_class.new(type: type, show_first: show_first).markdown(input) }
+  subject(:markdown) { described_class.create(type: type, show_first: show_first).markdown(input) }
 
   before do
     allow(input).to receive(:failures).and_return(failures)
@@ -121,8 +121,37 @@ RSpec.describe TestSummaryBuildkitePlugin::Formatter do
       it 'includes the label' do
         expect(markdown).to include('animals')
       end
+
       it 'includes the summary' do
         expect(markdown).to include('ponies are awesome')
+      end
+    end
+  end
+
+  describe 'count_only' do
+    let(:type) { 'count_only' }
+
+    context 'with no failures' do
+      let(:failures) { [] }
+
+      it 'returns empty markdown' do
+        expect(markdown).to be_nil
+      end
+    end
+
+    context 'with failures' do
+      let(:failures) { [TestSummaryBuildkitePlugin::Failure::Unstructured.new('ponies are awesome')] }
+
+      it 'includes the label' do
+        expect(markdown).to include('animals')
+      end
+
+      it 'includes the count' do
+        expect(markdown).to include('1')
+      end
+
+      it 'does not include the summary' do
+        expect(markdown).not_to include('ponies are awesome')
       end
     end
   end
@@ -196,7 +225,7 @@ RSpec.describe TestSummaryBuildkitePlugin::Formatter do
   end
 
   describe 'with no formatter options' do
-    subject(:markdown) { described_class.new.markdown(input) }
+    subject(:markdown) { described_class.create.markdown(input) }
     let(:failures) do
       [TestSummaryBuildkitePlugin::Failure::Structured.new(
         name: 'ponies are awesome',


### PR DESCRIPTION
Goes `details` -> `summary` -> `count_only`, where `count_only` is

<img width="1156" alt="screen shot 2018-05-10 at 4 18 38 pm" src="https://user-images.githubusercontent.com/4583474/39855091-d94120dc-546d-11e8-9d93-e61492bf8987.png">


closes #8 