### PR TITLE
Workaround redcarpet formatting issues

### DIFF
--- a/lib/test_summary_buildkite_plugin/formatter.rb
+++ b/lib/test_summary_buildkite_plugin/formatter.rb
@@ -53,8 +53,9 @@ module TestSummaryBuildkitePlugin
       end
 
       def details(summary, contents)
-        # The empty paragraph puts padding between the details and the following element
-        "<details><summary>#{summary}</summary>\n#{contents}\n</details><p></p>"
+        # This indents the close tag of nested <details> elements to work around a bug in redcarpet
+        # See https://github.com/vmg/redcarpet/issues/652
+        "<details>\n<summary>#{summary}</summary>\n#{contents.gsub(%r{^</details>}, '  </details>')}\n</details>"
       end
 
       def type


### PR DESCRIPTION
Buildkite uses redcarpet to render the markdown and redcarpet has [some issues](https://github.com/vmg/redcarpet/issues/652) with nested html block elements. Basically if you have:

```
<details>
<details>
</details>
</details>
```

Redcarpet thinks the first `</details>` is the end of the HTML content and parses everything after that as markdown, causing formatting issues. The easiest solution I can see is to indent the nested content but (a) `haml` no longer supports pretty formatting the output and (b) we can't just blindly indent all the contents because of the `<pre>` elements. So this indents just the nested`</details>` lines which is a dodgy hack but it works so /shrug.