### PR TITLE
Remove redcarpet workarounds

### DIFF
--- a/bin/run-dev
+++ b/bin/run-dev
@@ -20,8 +20,7 @@ module TestSummaryBuildkitePlugin
       log(args, stdin: stdin)
       if args.first == 'annotate'
         context = args[2]
-        # Buildkite uses Redcarpet but that requires native extensions that don't (easily) work in alpine
-        # so we use Kramdown for testing purposes
+        # Buildkite uses a different rendering engine but Kramdown is close enough
         content = Kramdown::Document.new(stdin).to_html
         html = HamlRender.render('test_layout', content: content)
         FileUtils.mkdir_p('tmp')

--- a/lib/test_summary_buildkite_plugin/formatter.rb
+++ b/lib/test_summary_buildkite_plugin/formatter.rb
@@ -56,9 +56,7 @@ module TestSummaryBuildkitePlugin
       end
 
       def details(summary, contents)
-        # This indents the close tag of nested <details> elements to work around a bug in redcarpet
-        # See https://github.com/vmg/redcarpet/issues/652
-        "<details>\n<summary>#{summary}</summary>\n#{contents.gsub(%r{^</details>}, '  </details>')}\n</details>"
+        "<details>\n<summary>#{summary}</summary>\n#{contents}\n</details>"
       end
 
       def type


### PR DESCRIPTION
Buildkite isn't using redcarpet anymore so we don't need to work around its limitations.

Original workarounds added in #17.