### PR TITLE
Avoid blank lines in html details because CommonMark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:2.5.1-alpine
 RUN mkdir -p /opt/gems
 COPY Gemfile Gemfile.lock /opt/gems/
 WORKDIR /opt/gems
-RUN bundle install --deployment
+RUN bundle install --deployment --without development
 
 ENV APP_DIR=/usr/src/app
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,14 @@ gem 'bundler', '~> 1.16'
 gem 'haml'
 
 group :development, :test do
-  gem 'kramdown'
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.0'
   gem 'rspec_junit_formatter'
   gem 'rubocop'
+end
+
+group :development do
+  gem 'commonmarker'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    commonmarker (0.17.9)
+      ruby-enum (~> 0.5)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     docile (1.3.0)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
-    kramdown (1.17.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
@@ -37,6 +41,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-enum (0.7.2)
+      i18n
     ruby-progressbar (1.9.0)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -52,8 +58,8 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  commonmarker
   haml
-  kramdown
   rake (~> 10.0)
   rspec (~> 3.0)
   rspec_junit_formatter

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -5,7 +5,7 @@ require 'bundler/setup'
 require 'pathname'
 $LOAD_PATH.unshift(Pathname.new(__FILE__).dirname.dirname.join('lib').to_s)
 
-require 'kramdown'
+require 'commonmarker'
 require 'yaml'
 require 'test_summary_buildkite_plugin'
 
@@ -20,8 +20,7 @@ module TestSummaryBuildkitePlugin
       log(args, stdin: stdin)
       if args.first == 'annotate'
         context = args[2]
-        # Buildkite uses a different rendering engine but Kramdown is close enough
-        content = Kramdown::Document.new(stdin).to_html
+        content = CommonMarker.render_html(stdin)
         html = HamlRender.render('test_layout', content: content)
         FileUtils.mkdir_p('tmp')
         out = Pathname.new('tmp').join(context + '.html')

--- a/lib/test_summary_buildkite_plugin/formatter.rb
+++ b/lib/test_summary_buildkite_plugin/formatter.rb
@@ -76,7 +76,11 @@ module TestSummaryBuildkitePlugin
       end
 
       def render_template(name, params)
-        HamlRender.render(name, params, folder: type)
+        # In CommonMark (used by buildkite), most html block elements are terminated by a blank line
+        # So we need to ensure we don't have any of those in the middle of our html
+        #
+        # See https://spec.commonmark.org/0.28/#html-blocks
+        HamlRender.render(name, params, folder: type)&.gsub(/\n\n/, "\n&nbsp;\n")
       end
     end
 

--- a/lib/test_summary_buildkite_plugin/formatter.rb
+++ b/lib/test_summary_buildkite_plugin/formatter.rb
@@ -80,7 +80,7 @@ module TestSummaryBuildkitePlugin
         # So we need to ensure we don't have any of those in the middle of our html
         #
         # See https://spec.commonmark.org/0.28/#html-blocks
-        HamlRender.render(name, params, folder: type)&.gsub(/\n\n/, "\n&nbsp;\n")
+        HamlRender.render(name, params, folder: type)&.gsub(/\n\n+/, "\n&nbsp;\n")
       end
     end
 

--- a/spec/sample_artifacts/xunit.xml
+++ b/spec/sample_artifacts/xunit.xml
@@ -20,4 +20,36 @@
     </testcase>
     <testcase classname="Login should log in successfully" name="Login should log in successfully" time="0.028"></testcase>
   </testsuite>
+  <testsuite name="HeaderStore" errors="0" failures="1" skipped="0" timestamp="2018-07-25T03:01:53" time="0.678" tests="7">
+    <testcase classname="Header › matches snapshot" name="Header › matches snapshot" time="0.03">
+      <failure>Error: expect(value).toMatchSnapshot()
+
+Received value does not match stored snapshot &quot;Header matches snapshot 1&quot;.
+
+- Snapshot
++ Received
+
+@@ -3,11 +3,11 @@
+  &gt;
+    &lt;nav
+      class=&quot;startGroup&quot;
+    &gt;
+      &lt;a
+-       class=&quot;base anchor button booo homeLink&quot;
++       class=&quot;base anchor button linkButton homeLink&quot;
+        href=&quot;/&quot;
+      &gt;
+        &lt;span
+          class=&quot;text&quot;
+        &gt;
+    at Object.toMatchRenderedSnapshot (/build/web/tools/jest/matchers/to_match_rendered_snapshot.ts:9:25)
+    at Object.throwingMatcher [as toMatchRenderedSnapshot] (/build/web/node_modules/expect/build/index.js:316:33)
+    at Object.it (/build/web/src/pages/editor/header/tests/header.tests.tsx:76:9)
+    at Object.asyncFn (/build/web/node_modules/jest-jasmine2/build/jasmine_async.js:108:37)
+    at resolve (/build/web/node_modules/jest-jasmine2/build/queue_runner.js:56:12)
+    at new Promise (&lt;anonymous&gt;)
+    at mapper (/build/web/node_modules/jest-jasmine2/build/queue_runner.js:43:19)
+    at promise.then (/build/web/node_modules/jest-jasmine2/build/queue_runner.js:87:41)</failure>
+    </testcase>
+  </testsuite>
 </testsuites>

--- a/spec/sample_artifacts/xunit.xml
+++ b/spec/sample_artifacts/xunit.xml
@@ -24,6 +24,7 @@
     <testcase classname="Header › matches snapshot" name="Header › matches snapshot" time="0.03">
       <failure>Error: expect(value).toMatchSnapshot()
 
+
 Received value does not match stored snapshot &quot;Header matches snapshot 1&quot;.
 
 - Snapshot

--- a/spec/test_summary_buildkite_plugin/formatter_spec.rb
+++ b/spec/test_summary_buildkite_plugin/formatter_spec.rb
@@ -103,6 +103,14 @@ RSpec.describe TestSummaryBuildkitePlugin::Formatter do
           expect(markdown).to include('&amp;')
         end
       end
+
+      context 'with blank lines in description' do
+        let(:details) { "one\n\ntwo" }
+
+        it 'adds nbsp so CommonMark does not terminate the block' do
+          expect(markdown).to include("one\n&nbsp;\ntwo")
+        end
+      end
     end
   end
 

--- a/spec/test_summary_buildkite_plugin/formatter_spec.rb
+++ b/spec/test_summary_buildkite_plugin/formatter_spec.rb
@@ -111,6 +111,14 @@ RSpec.describe TestSummaryBuildkitePlugin::Formatter do
           expect(markdown).to include("one\n&nbsp;\ntwo")
         end
       end
+
+      context 'with multiple consecutive blank lines in description' do
+        let(:details) { "one\n\n\n\ntwo" }
+
+        it 'strips subsequent blank lines' do
+          expect(markdown).to include("one\n&nbsp;\ntwo")
+        end
+      end
     end
   end
 

--- a/spec/test_summary_buildkite_plugin/input_spec.rb
+++ b/spec/test_summary_buildkite_plugin/input_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe TestSummaryBuildkitePlugin::Input do
       end
 
       it 'ignores skipped test' do
-        expect(input.failures.count).to eq(2)
+        expect(input.failures.count).to eq(3)
       end
 
       it 'when message is not present has a nil message' do

--- a/templates/test_layout.html.haml
+++ b/templates/test_layout.html.haml
@@ -7,7 +7,7 @@
     %title Test markdown
     %link{href: "https://buildkiteassets.com/assets/vendor-db6715eb432e97e75e96d7f9daf1836e3fba33f941a73503d4a17ef23007a382.css", media: "screen", rel: "stylesheet"}/
     %link{href: "https://buildkiteassets.com/assets/application-e36dfd37301763b9c80dd8ce6264754d5aec8564ec65a374e1dafed2b969a5f0.css", media: "screen", rel: "stylesheet"}/
-    %link{href: "https://buildkiteassets.com/frontend/99b298583caaa3dae11f4b23e140f1a3fad57a42/app-b96827579a6b81e418d5e0c36c81ed5e.css", rel: "stylesheet"}/
+    %link{href: "https://buildkiteassets.com/frontend/99b298583caaa3dae11f4b23e140f1a3fad57a42/app-f9b0a7b638e2a2d52d9405eedb9e9325.css", rel: "stylesheet"}/
     %meta{content: "origin-when-cross-origin", name: "referrer"}/
   %body.new-nav
     .twbs-container


### PR DESCRIPTION
Buildkite recently changed their markdown renderer to [cmark-gfm](https://github.com/brokenhandsio/cmark-gfm). CommonMark terminates most html blocks with a blank line. This caused errors if the details of an issue contain blank lines. The "solution" here is to replace blank lines with a `&nbsp;` so it's not considered blank.

Also updates the markdown renderer in dev to be CommonMark compliant and bumps the dev buildkite css.

Fixes #24 