### PR TITLE
Remove undocumented count-only formatter

### DIFF
--- a/lib/test_summary_buildkite_plugin/formatter.rb
+++ b/lib/test_summary_buildkite_plugin/formatter.rb
@@ -23,6 +23,8 @@ module TestSummaryBuildkitePlugin
         [heading(input), input_markdown(input), footer(input)].compact.join("\n\n")
       end
 
+      protected
+
       def input_markdown(input)
         if show_first.negative? || show_first >= include_failures(input).count
           failures_markdown(include_failures(input))
@@ -88,17 +90,9 @@ module TestSummaryBuildkitePlugin
 
     class Details < Base; end
 
-    class CountOnly < Base
-      def markdown(input)
-        return nil if input.failures.count.zero?
-        heading(input)
-      end
-    end
-
     TYPES = {
       summary: Formatter::Summary,
-      details: Formatter::Details,
-      count_only: Formatter::CountOnly
+      details: Formatter::Details
     }.freeze
   end
 end

--- a/spec/test_summary_buildkite_plugin/formatter_spec.rb
+++ b/spec/test_summary_buildkite_plugin/formatter_spec.rb
@@ -146,34 +146,6 @@ RSpec.describe TestSummaryBuildkitePlugin::Formatter do
     end
   end
 
-  describe 'count_only' do
-    let(:type) { 'count_only' }
-
-    context 'with no failures' do
-      let(:failures) { [] }
-
-      it 'returns empty markdown' do
-        expect(markdown).to be_nil
-      end
-    end
-
-    context 'with failures' do
-      let(:failures) { [TestSummaryBuildkitePlugin::Failure::Unstructured.new('ponies are awesome')] }
-
-      it 'includes the label' do
-        expect(markdown).to include('animals')
-      end
-
-      it 'includes the count' do
-        expect(markdown).to include('1')
-      end
-
-      it 'does not include the summary' do
-        expect(markdown).not_to include('ponies are awesome')
-      end
-    end
-  end
-
   describe 'show_first' do
     let(:type) { 'summary' }
     let(:show_first) { 2 }


### PR DESCRIPTION
Internal use of this was removed in #18 and it was never documented. So lets just get rid of it.