### PR TITLE
support agent socket mode

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -30,5 +30,7 @@ fi
 
 docker run --rm \
   --mount type=bind,src=$(which buildkite-agent),dst=/usr/bin/buildkite-agent \
-  -e BUILDKITE_BUILD_ID -e BUILDKITE_JOB_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -e BUILDKITE_PLUGINS \
+  --mount type=bind,src=/tmp,dst=/tmp \
+  -e BUILDKITE_BUILD_ID -e BUILDKITE_JOB_ID -e BUILDKITE_PLUGINS \
+  -e BUILDKITE_AGENT_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -e BUILDKITE_AGENT_ENDPOINT   \
   $IMAGE


### PR DESCRIPTION
this is a fast-n-dirty solution. 

Mounting all the `/tmp` might be an overkill but otherwise we'll have to branch depending on if the socket mode is enabled or not - this in turn will lead to dynamic `docker run` command generation.

I don't like Bash that much to do this at once, but if you think we should make this nicer - I'll do that