### PR TITLE
Use correct links to jobs post buildkite update

### DIFF
--- a/templates/details/failures.html.haml
+++ b/templates/details/failures.html.haml
@@ -22,7 +22,7 @@
             - if failure.job_id
               %dt Job
               %dd
-                %a{href: "#job-component-#{failure.job_id}"}
+                %a{href: "##{failure.job_id}"}
                   = failure.job_id
       - else
         %code

--- a/templates/summary/footer.html.haml
+++ b/templates/summary/footer.html.haml
@@ -2,10 +2,10 @@
 - unless job_ids.empty?
   See
   - job_ids[0...-2].each do |job_id|
-    = "[job #{job_id}](#job-component-#{job_id}),"
+    = "[job #{job_id}](##{job_id}),"
 
   - if job_ids.count > 1
-    = "[job #{job_ids[-2]}](#job-component-#{job_ids[-2]})"
+    = "[job #{job_ids[-2]}](##{job_ids[-2]})"
     and
 
-  = "[job #{job_ids.last}](#job-component-#{job_ids.last})"
+  = "[job #{job_ids.last}](##{job_ids.last})"


### PR DESCRIPTION
We used to link to jobs using the `#job-component-<uuid>` id because using the job link directly didn't work. This correctly scrolled to the job but didn't open the log output. Now that buildkite supports using `#<uuid>` from annotations we should do that instead so the logs do open.

See https://buildkite.com/changelog/39-link-to-jobs-from-annotations.