### PR TITLE
junit: Allow disabling the message or details if they aren't relevant

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,6 +86,7 @@ steps:
               type: junit
               encoding: UTF-8
               strip_colors: true
+              message: false
               summary:
                 format: '%{location}: %{testcase.name}'
                 details_regex: '(?<location>\S+:\d+)[^\n]*\z'

--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ crop:
 * `job_id_regex:` Ruby regular expression to extract the `job_id` from the artifact path. It must contain
   a named capture with the name `job_id`. Defaults to
   `(?<job_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`.
-* `summary:` (`junit` type only) Customise how the summary is generated. Includes:
+
+#### Junit specific options:
+
+* `summary:` Customise how the summary is generated. Includes:
     * `format:` A ruby format string for converting the junit xml attributes
       into a summary. All attributes are available in `<element>.<attr-name>` format.
     * `details_regex:` A ruby regular expression, run over the body text of each failure. Any named captures
@@ -118,6 +121,9 @@ summary:
   format: '%{location}: %{testcase.name}'
   details_regex: '(?<location>\S+:\d+)'
 ```
+
+* `message:` Set this to false if the failure `message` attribute is not worth showing in the annotation. Defaults to `true`.
+* `details:` Set this to false if the body of the failure is not worth showing in the annotation. Defaults to `true`.
 
 ### Formatter
 

--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -104,7 +104,7 @@ module TestSummaryBuildkitePlugin
           testcase.elements.each('failure | error') do |failure|
             failures << Failure::Structured.new(
               summary: summary(failure),
-              message: failure.attributes['message']&.to_s,
+              message: message(failure),
               details: details(failure)
             )
           end
@@ -150,8 +150,14 @@ module TestSummaryBuildkitePlugin
       end
 
       def details(failure)
-        # gets all text elements that are direct children (includes CDATA), and use the unescaped values
-        failure.texts.map(&:value).join('').strip
+        if options.fetch(:details, true)
+          # gets all text elements that are direct children (includes CDATA), and use the unescaped values
+          failure.texts.map(&:value).join('').strip
+        end
+      end
+
+      def message(failure)
+        failure.attributes['message']&.to_s if options.fetch(:message, true)
       end
 
       def summary_format

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,6 +25,10 @@ configuration:
             type: string
           strip_colors:
             type: boolean
+          message:
+            type: boolean
+          details:
+            type: boolean
           crop:
             type: object
             properties:

--- a/spec/test_summary_buildkite_plugin/input_spec.rb
+++ b/spec/test_summary_buildkite_plugin/input_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe TestSummaryBuildkitePlugin::Input do
       expect(input.failures.first.details).to start_with('Failure/Error: ')
     end
 
+    it 'failures have message' do
+      expect(input.failures.first.message).to start_with('expected http://')
+    end
+
     it 'failures have file' do
       expect(input.failures.first.summary).to include('./spec/lib/url_whitelist_spec.rb')
     end
@@ -151,6 +155,26 @@ RSpec.describe TestSummaryBuildkitePlugin::Input do
             )
           )
         end
+      end
+    end
+
+    context 'disabling message' do
+      let(:additional_options) do
+        { message: false }
+      end
+
+      it 'ignores the message' do
+        expect(input.failures.first.message).to be_nil
+      end
+    end
+
+    context 'disabling details' do
+      let(:additional_options) do
+        { details: false }
+      end
+
+      it 'ignores the details' do
+        expect(input.failures.first.details).to be_nil
       end
     end
   end


### PR DESCRIPTION
The rspec junit formatter repeats the same content for the message and the details. This allows disabling one while having sensible defaults for most other junit formatters.