### PR TITLE
Fix bin/run-dev to work with the new array syntax

### DIFF
--- a/bin/run-dev
+++ b/bin/run-dev
@@ -35,9 +35,9 @@ end
 pipeline_sample = YAML.load_file('.buildkite/pipeline.yml')
 
 pipeline_sample['steps'].each do |step|
-  next unless step['plugins']&.find { |k, _| k.include?('test-summary') }
+  next unless step['plugins']&.any? { |plugin| plugin.find { |k, _| k.include?('test-summary') } }
 
   # Roughly match the formatting that buildkite gives
-  ENV['BUILDKITE_PLUGINS'] = [step['plugins']].to_json
+  ENV['BUILDKITE_PLUGINS'] = step['plugins'].to_json
   TestSummaryBuildkitePlugin.run
 end


### PR DESCRIPTION
This commit https://github.com/bugcrowd/test-summary-buildkite-plugin/commit/adbae07856a8de3270d3aad0e34aae6a98e018f2 broke the run-dev script, because `step['plugins']` is now no longer a hash, but an array of hashes.