### PR TITLE
Update `MAX_MARKDOWN_SIZE` to 100kb

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Other formatter options are:
   
 ## Truncation
 
-Buildkite has a maximum annotation size of 50 kilobytes. If there are too many failures to fit within this limit, the
+Buildkite has a maximum annotation size of 100 kilobytes. If there are too many failures to fit within this limit, the
 plugin will truncate the failures for each input.
 
 ## Developing

--- a/lib/test_summary_buildkite_plugin/runner.rb
+++ b/lib/test_summary_buildkite_plugin/runner.rb
@@ -2,7 +2,7 @@
 
 module TestSummaryBuildkitePlugin
   class Runner
-    MAX_MARKDOWN_SIZE = 50_000
+    MAX_MARKDOWN_SIZE = 100_000
 
     attr_reader :options
 


### PR DESCRIPTION
Buildkite’s maximum annotation size is now 100kb, so this can be adjusted to suit!