### PR TITLE
Add option `mount_in_buildkite_agent`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM buildkite/agent:3 as buildkite-agent
+
 FROM ruby:2.5.1-alpine
 
 # Fetch/install gems
@@ -10,6 +12,9 @@ ENV APP_DIR=/usr/src/app
 
 COPY . $APP_DIR
 RUN mkdir -p $APP_DIR/vendor && ln -s /opt/gems/vendor/bundle $APP_DIR/vendor/bundle
+
+RUN mkdir -p /usr/local/bin
+COPY --from=buildkite-agent /usr/local/bin/buildkite-agent /usr/local/bin/
 
 WORKDIR $APP_DIR
 CMD ["./bin/run"]

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Other formatter options are:
 * `style:` Set the annotation style. Defaults to `error`.
 * `fail_on_error:` Whether the command should return non-zero exit status on failure. Defaults to `false` so failing
   to annotate a build does not cause the entire pipeline to fail.
+* `mount_in_buildkite_agent:` Whether to bind mount `buildkite-agent` into the container. The `bugcrowd/test-summary-buildkite-plugin` image has `buildkite-agent` v3 installed. This option is useful if the agent itself is running in a container, thus it can't bind mount the agent binary directly into the container. Defaults to `true`, i.e. the same agent binary performing the build will be mounted in.
   
 ## Truncation
 

--- a/hooks/command
+++ b/hooks/command
@@ -28,8 +28,13 @@ else
     docker build -t "$IMAGE" .
 fi
 
+MOUNT_AGENT=""
+if [[ "${BUILDKITE_PLUGIN_TEST_SUMMARY_MOUNT_IN_BUILDKITE_AGENT:-true}" = "true" ]]; then
+    MOUNT_AGENT="--mount type=bind,src=$(which buildkite-agent),dst=/usr/bin/buildkite-agent"
+fi
+
 docker run --rm \
-  --mount type=bind,src=$(which buildkite-agent),dst=/usr/bin/buildkite-agent \
+  $MOUNT_AGENT \
   --mount type=bind,src=/tmp,dst=/tmp \
   -e BUILDKITE_BUILD_ID -e BUILDKITE_JOB_ID -e BUILDKITE_PLUGINS \
   -e BUILDKITE_AGENT_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -e BUILDKITE_AGENT_ENDPOINT   \

--- a/plugin.yml
+++ b/plugin.yml
@@ -66,6 +66,8 @@ configuration:
       type: string
     fail_on_error:
       type: boolean
+    mount_in_buildkite_agent:
+      type: boolean
   required:
     - inputs
   additionalProperties: false


### PR DESCRIPTION
This adds a new option, `mount_in_buildkite_agent`, configuring whether to bind mount `buildkite-agent` into the container. I also added `buildkite-agent` to the `bugcrowd/test-summary-buildkite-plugin` image, so it has a default version installed. This option is useful if the agent itself is running in a containerized environment, thus it can't bind mount the agent binary directly into the container it starts.

The option defaults to `true`, i.e. the same agent binary performing the build will be mounted in (thus not breaking the current behavior).
