### PR TITLE
Skip image pull if possible

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -19,9 +19,13 @@ cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 TAG=$(git describe --tags --exact-match 2> /dev/null || true)
 
 if [[ -n "$TAG" ]]; then
-    echo "Found tag $TAG, pulling from docker hub"
     IMAGE="$DOCKER_REPO:$TAG"
-    docker pull "$IMAGE"
+    if ! docker image inspect "$IMAGE" &> /dev/null; then
+        echo "Pulling tag $TAG from docker hub"
+        docker pull "$IMAGE"
+    else
+        echo "Tag $TAG already exists locally, skipping pull"
+    fi
 else
     echo "No tag found, building image locally"
     IMAGE=test-summary:$BUILDKITE_JOB_ID


### PR DESCRIPTION
Now that dockerhub has enforced rate limiting on image pulls, it would be nice to skip the `docker pull` if the image already exists (performing a pull still counts against the rate limit even if the image is not updated). This implements a simple check to see if the correctly tagged image already exists locally, and simply uses that image if so.