### PR TITLE
Handle error in parsing single file

### DIFF
--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -40,12 +40,8 @@ module TestSummaryBuildkitePlugin
           Agent.run('artifact', 'download', artifact_path, WORKDIR)
           Dir.glob("#{WORKDIR}/#{artifact_path}")
         rescue Agent::CommandFailed => err
-          if fail_on_error
-            raise
-          else
-            Utils.log_error(err)
-            []
-          end
+          handle_error(err)
+          []
         end
       end
 
@@ -63,6 +59,9 @@ module TestSummaryBuildkitePlugin
 
       def filename_to_failures(filename)
         file_contents_to_failures(read(filename)).each { |failure| failure.job_id = job_id(filename) }
+      rescue StandardError => err
+        handle_error(err)
+        []
       end
 
       def job_id(filename)
@@ -76,6 +75,14 @@ module TestSummaryBuildkitePlugin
           r
         else
           DEFAULT_JOB_ID_REGEX
+        end
+      end
+
+      def handle_error(err)
+        if fail_on_error
+          raise err
+        else
+          Utils.log_error(err)
         end
       end
     end

--- a/spec/test_summary_buildkite_plugin/input_spec.rb
+++ b/spec/test_summary_buildkite_plugin/input_spec.rb
@@ -265,7 +265,7 @@ severity: fail')
   describe 'setting ascii encoding' do
     let(:type) { 'oneline' }
     let(:artifact_path) { 'eslint-00112233-0011-0011-0011-001122334455.txt' }
-    let(:additional_options) { { encoding: 'ascii' } }
+    let(:additional_options) { { encoding: 'ascii', fail_on_error: true } }
 
     it 'tries to parse as ascii' do
       expect { input.failures }.to raise_error('invalid byte sequence in US-ASCII')
@@ -301,7 +301,7 @@ severity: fail')
     end
 
     context 'with bad custom job_id_regex' do
-      let(:additional_options) { { job_id_regex: '(eslint)' } }
+      let(:additional_options) { { job_id_regex: '(eslint)', fail_on_error: true } }
       let(:artifact_path) { 'eslint-00112233-0011-0011-0011-001122334455.txt' }
 
       it 'gives helpful error' do
@@ -335,6 +335,28 @@ severity: fail')
 
       it 'raises error' do
         expect { input.failures }.to raise_error(TestSummaryBuildkitePlugin::Agent::CommandFailed)
+      end
+    end
+  end
+
+  describe 'parsing exceptions' do
+    let(:type) { 'oneline' }
+    let(:artifact_path) { 'rubocop.txt' }
+
+    before do
+      allow(input).to receive(:file_contents_to_failures).and_raise('no good')
+    end
+
+    it 'handles the error' do
+      expect { input.failures }.to output(/no good/).to_stdout
+      expect(input.failures).to be_empty
+    end
+
+    describe 'with fail_on_error' do
+      let(:additional_options) { { fail_on_error: true } }
+
+      it 're-raises the error' do
+        expect { input.failures }.to raise_error('no good')
       end
     end
   end


### PR DESCRIPTION
Flexport has been getting intermittent REXML failures from Jest XML output for a while. The artifacts themselves seem fine; it's possible the files are getting corrupted during download. We're investigating the proper fix for our own problem, but this seems like a defensive measure with wide applicability: a failure in processing a single artifact should still allow the rest to proceed (unless configured otherwise).