### PR TITLE
Add option to run without docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Other formatter options are:
 * `style:` Set the annotation style. Defaults to `error`.
 * `fail_on_error:` Whether the command should return non-zero exit status on failure. Defaults to `false` so failing
   to annotate a build does not cause the entire pipeline to fail.
+* `run_without_docker:` Set the enviroment to run without docker. Defaults to `false`.
   
 ## Truncation
 

--- a/hooks/command
+++ b/hooks/command
@@ -16,22 +16,28 @@ trap on_failure ERR
 
 # cd to plugin directory
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
-TAG=$(git describe --tags --exact-match 2> /dev/null || true)
 
-if [[ -n "$TAG" ]]; then
-    echo "Found tag $TAG, pulling from docker hub"
-    IMAGE="$DOCKER_REPO:$TAG"
-    docker pull "$IMAGE"
+if [[ ${BUILDKITE_PLUGIN_TEST_SUMMARY_RUN_WITHOUT_DOCKER:-false} = true ]]; then
+    ./bin/setup
+    ./bin/run
 else
-    echo "No tag found, building image locally"
-    IMAGE=test-summary:$BUILDKITE_JOB_ID
-    docker build -t "$IMAGE" .
-fi
+    TAG=$(git describe --tags --exact-match 2> /dev/null || true)
 
-docker run --rm \
-  --mount type=bind,src=$(which buildkite-agent),dst=/usr/bin/buildkite-agent \
-  --mount type=bind,src=/tmp,dst=/tmp \
-  -e BUILDKITE_BUILD_ID -e BUILDKITE_JOB_ID -e BUILDKITE_PLUGINS \
-  -e BUILDKITE_AGENT_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -e BUILDKITE_AGENT_ENDPOINT   \
-  -e HTTP_PROXY -e HTTPS_PROXY \
-  $IMAGE
+    if [[ -n "$TAG" ]]; then
+        echo "Found tag $TAG, pulling from docker hub"
+        IMAGE="$DOCKER_REPO:$TAG"
+        docker pull "$IMAGE"
+    else
+        echo "No tag found, building image locally"
+        IMAGE=test-summary:$BUILDKITE_JOB_ID
+        docker build -t "$IMAGE" .
+    fi
+
+    docker run --rm \
+    --mount type=bind,src=$(which buildkite-agent),dst=/usr/bin/buildkite-agent \
+    --mount type=bind,src=/tmp,dst=/tmp \
+    -e BUILDKITE_BUILD_ID -e BUILDKITE_JOB_ID -e BUILDKITE_PLUGINS \
+    -e BUILDKITE_AGENT_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -e BUILDKITE_AGENT_ENDPOINT   \
+    -e HTTP_PROXY -e HTTPS_PROXY \
+    $IMAGE
+fi

--- a/hooks/command
+++ b/hooks/command
@@ -34,10 +34,10 @@ else
     fi
 
     docker run --rm \
-    --mount type=bind,src=$(which buildkite-agent),dst=/usr/bin/buildkite-agent \
-    --mount type=bind,src=/tmp,dst=/tmp \
-    -e BUILDKITE_BUILD_ID -e BUILDKITE_JOB_ID -e BUILDKITE_PLUGINS \
-    -e BUILDKITE_AGENT_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -e BUILDKITE_AGENT_ENDPOINT   \
-    -e HTTP_PROXY -e HTTPS_PROXY \
-    $IMAGE
+      --mount type=bind,src=$(which buildkite-agent),dst=/usr/bin/buildkite-agent \
+      --mount type=bind,src=/tmp,dst=/tmp \
+      -e BUILDKITE_BUILD_ID -e BUILDKITE_JOB_ID -e BUILDKITE_PLUGINS \
+      -e BUILDKITE_AGENT_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -e BUILDKITE_AGENT_ENDPOINT   \
+      -e HTTP_PROXY -e HTTPS_PROXY \
+      $IMAGE
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -66,6 +66,8 @@ configuration:
       type: string
     fail_on_error:
       type: boolean
+    run_without_docker:
+      type: boolean
   required:
     - inputs
   additionalProperties: false


### PR DESCRIPTION
Addresses the issue #68 feature request to optionally run this plugin in a ruby environment without access to docker.