### PR TITLE
[FIX] Optimize JUnit processing time for large test results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- JUnit: Optimize processing time for large test results with many passing testcases
+
 ## [v1.11.0](https://github.com/bugcrowd/test-summary-buildkite-plugin/compare/v1.10.0...v1.11.0) - 2020-01-28
 - Forward `HTTP_PROXY` ENV var to respect proxies [#58](https://github.com/bugcrowd/test-summary-buildkite-plugin/pull/58)
 

--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -107,7 +107,8 @@ module TestSummaryBuildkitePlugin
     class JUnit < Base
       def file_contents_to_failures(str)
         xml = REXML::Document.new(str)
-        xml.elements.enum_for(:each, '//testcase').each_with_object([]) do |testcase, failures|
+        failed_testcases = xml.elements.enum_for(:each, '//*[self::testcase][failure or error]')
+        failed_testcases.each_with_object([]) do |testcase, failures|
           testcase.elements.each('failure | error') do |failure|
             failures << Failure::Structured.new(
               summary: summary(failure),

--- a/spec/test_summary_buildkite_plugin/input_spec.rb
+++ b/spec/test_summary_buildkite_plugin/input_spec.rb
@@ -177,6 +177,80 @@ RSpec.describe TestSummaryBuildkitePlugin::Input do
         expect(input.failures.first.details).to be_nil
       end
     end
+
+    context 'with failure and error elements in one testcase' do
+      let(:mixed_failure_junit) do
+        <<~XML
+          <testsuite>
+            <testcase name="mixed">
+              <error message="error first in XML"/>
+              <failure message="failure second in XML"/>
+            </testcase>
+          </testsuite>
+        XML
+      end
+
+      it 'preserves failure-before-error ordering' do
+        failures = input.file_contents_to_failures(mixed_failure_junit)
+
+        expect(failures.map(&:message)).to eq(['failure second in XML', 'error first in XML'])
+      end
+    end
+
+    context 'with many passing sibling testcases' do
+      let(:additional_options) do
+        {
+          summary: {
+            format: '%{testsuites.name}: %{testsuite.name}: %{testcase.name} '\
+                    '(%{failure.message}%{error.message})'
+          }
+        }
+      end
+      let(:wide_junit) do
+        testcases = Array.new(2_000) do |index|
+          case index
+          when 500
+            '<testcase name="early error"><error message="boom">error details</error></testcase>'
+          when 1_500
+            '<testcase name="late failure"><failure message="bang">failure details'\
+              '<error message="nested error"/></failure></testcase>'
+          else
+            %(<testcase name="passing #{index}"/>)
+          end
+        end.join
+
+        <<~XML
+          <testsuites name="root">
+            <testsuite name="wide">
+              <error message="suite-level error"/>
+              #{testcases}
+            </testsuite>
+          </testsuites>
+        XML
+      end
+
+      it 'preserves testcase failure and error output in document order' do
+        failures = input.file_contents_to_failures(wide_junit)
+
+        expect(failures.map { |failure| [failure.summary, failure.message, failure.details] }).to eq(
+          [
+            ['root: wide: early error (boom)', 'boom', 'error details'],
+            ['root: wide: late failure (bang)', 'bang', 'failure details']
+          ]
+        )
+      end
+
+      it 'does not build sibling indexes for every passing testcase' do
+        parent_index_calls = 0
+        trace = TracePoint.new(:call) do |event|
+          parent_index_calls += 1 if event.defined_class == REXML::Parent && event.method_id == :index
+        end
+
+        trace.enable { input.file_contents_to_failures(wide_junit) }
+
+        expect(parent_index_calls).to be < 100
+      end
+    end
   end
 
   describe 'with glob path' do


### PR DESCRIPTION
## Summary

- Filter REXML's XPath result set to `testcase` elements with a direct `failure` or `error` child.
- Retain the existing per-testcase `failure | error` traversal so failure/error ordering and formatting behavior remain unchanged.
- Add regression coverage for wide suites with mostly passing testcases and record the fix under `Unreleased`.

## Root cause

The JUnit parser currently evaluates `//testcase`, then inspects every matched testcase for failure or error children. REXML restores XPath matches to document order by constructing ancestor/sibling index paths, and `REXML::Parent#index` linearly scans siblings. For a wide suite with `N` sibling testcases, sorting all testcase matches therefore approaches O(N²), even when nearly every testcase passes.

The updated XPath is evaluated inside REXML:

```ruby
//*[self::testcase][failure or error]
```

REXML still parses and traverses the complete XML document, but passing testcases do not enter its expensive final result-ordering step. The existing inner `failure | error` traversal is unchanged.

Selecting `//failure | //error` directly would not be equivalent: it could include elements outside testcases and can change REXML's union ordering.

## Compatibility

The regression specs cover:

- both `failure` and `error` elements
- mixed failure/error children within one testcase
- direct-child semantics, excluding suite-level and nested errors
- nested suites and ancestor attributes used by custom summaries
- summary, message, and details output ordering
- a 2,000-testcase wide suite with deterministic bounds on `REXML::Parent#index` calls

## Validation

- `bundle exec rspec`: 107 examples, 0 failures
- `bundle exec rubocop`: 25 files inspected, no offenses detected
- Local compatibility environment: Ruby 2.6.10 and Bundler 1.17.2 (the repository declares Ruby 2.5.1 and Bundler 1.16.2)
